### PR TITLE
Make SSL work

### DIFF
--- a/lib/AnyEvent/Discord/Client.pm
+++ b/lib/AnyEvent/Discord/Client.pm
@@ -6,6 +6,7 @@ our $VERSION = '0.000002';
 $VERSION = eval $VERSION;
 
 use AnyEvent::WebSocket::Client;
+use Mozilla::CA;
 use LWP::UserAgent;
 use JSON;
 use URI;
@@ -139,7 +140,7 @@ sub connect {
   $self->{reconnect_delay} *= 2;
   $self->{reconnect_delay} = 5*60 if $self->{reconnect_delay} > 5*60;
 
-  $self->{websocket} = AnyEvent::WebSocket::Client->new(max_payload_size => 1024*1024);
+  $self->{websocket} = AnyEvent::WebSocket::Client->new(max_payload_size => 1024*1024, ssl_ca_file => Mozilla::CA::SSL_ca_file);
   $self->{websocket}->connect($self->{gateway})->cb(sub {
     $self->{conn} = eval { shift->recv };
     if($@) {


### PR DESCRIPTION
If AnyEvent::WebSocket::Client can't find the ssl_ca_file in the default location on your OS this module doesn't work at all. You either need to be able to pass one in, set ssl_no_verify => 1 (which leaves you open to man in the middle attacks), or include a CA, which is what this patch does.