### PR TITLE
$debug requires Data::Dumper

### DIFF
--- a/lib/AnyEvent/Discord/Client.pm
+++ b/lib/AnyEvent/Discord/Client.pm
@@ -12,6 +12,7 @@ use URI;
 use HTTP::Request;
 use HTTP::Headers;
 use AnyEvent::HTTP;
+use Data::Dumper;
 
 my $debug = 0;
 


### PR DESCRIPTION
If you enable $debug = 1, then the module will crash because Data::Dumper is not used with this message:

parse_error: Undefined subroutine &AnyEvent::Discord::Client::Dumper called at ...AnyEvent/Discord/Client.pm line 178