### PR TITLE
Added Mozilla certificate authority root certificates to the AnyEvent…

### DIFF
--- a/lib/AnyEvent/Discord/Client.pm
+++ b/lib/AnyEvent/Discord/Client.pm
@@ -6,6 +6,7 @@ our $VERSION = '0.000002';
 $VERSION = eval $VERSION;
 
 use AnyEvent::WebSocket::Client;
+use Mozilla::CA; 
 use LWP::UserAgent;
 use JSON;
 use URI;
@@ -139,7 +140,7 @@ sub connect {
   $self->{reconnect_delay} *= 2;
   $self->{reconnect_delay} = 5*60 if $self->{reconnect_delay} > 5*60;
 
-  $self->{websocket} = AnyEvent::WebSocket::Client->new(max_payload_size => 1024*1024);
+  $self->{websocket} = AnyEvent::WebSocket::Client->new(ssl_ca_file=> Mozilla::CA::SSL_ca_file(), max_payload_size => 1024*1024);
   $self->{websocket}->connect($self->{gateway})->cb(sub {
     $self->{conn} = eval { shift->recv };
     if($@) {


### PR DESCRIPTION
Added Mozilla certificate authority root certificates to the AnyEvent::WebSocket::Client. This resolves an error on Windows and will avoid the same issue on all platforms.

On Windows 10 64bit Strawberry Perl I was getting this error without this change
     Connecting to wss://gateway.discord.gg/?v=6&encoding=json...
connect error: tls_process_server_certificate: certificate verify failed at C:/StrawberryPerl/perl/site/lib/AnyEvent/Discord/Client.pm line 145.

This fix resolves this error that is similar to previously described issues and fixes. See for example
https://stackoverflow.com/questions/7662213/windows-perl-netssleay-openssl-what-locations-are-ca-certificates-loade
and
http://blogs.perl.org/users/brian_d_foy/2011/07/now-you-need-lwpprotocolhttps.html   